### PR TITLE
Reduce memory footprint

### DIFF
--- a/Bounce2/Bounce2.h
+++ b/Bounce2/Bounce2.h
@@ -41,22 +41,20 @@ public:
   // Attach to a pin (and also sets initial state)
   void attach(int pin);
 	// Sets the debounce interval
-  void interval(unsigned long interval_millis); 
+  void interval(uint16_t interval_millis);
 	// Updates the pin
 	// Returns 1 if the state changed
 	// Returns 0 if the state did not change
   bool update(); 
 	// Returns the updated pin state
-  uint8_t read();
+  bool read();
 
   
 protected:
-  int debounce();
-  unsigned long  previous_millis, interval_millis;
-  uint8_t debouncedState;
-  uint8_t unstableState;
+  unsigned long previous_millis;
+  uint16_t interval_millis;
+  uint8_t state;
   uint8_t pin;
-  uint8_t stateChanged;
 };
 
 #endif


### PR DESCRIPTION
Currently, Bounce2 uses 12 bytes of RAM per instance.
By packing a few of the boolean fields together, and reducing the size of the interval, I have reduced it to 8 bytes.

The interval_millis field should never realistically be set to over a uint16_t, which is 65535 (65.5 seconds).
A uint16_t is half the size of a long.

I also couldn't see why the read() function was returning a uint8_t, not a bool, so I changed it.
