### PR TITLE
Added pinMode setting to attach

### DIFF
--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -33,13 +33,8 @@ void Bounce::attach(int pin) {
 #endif
 }
 
-void Bounce::attach(int pin, byte mode){
-  if(mode == INPUT_PULLUP){
-    pinMode(pin, INPUT_PULLUP);
-  }
-  else{
-    pinMode(pin, INPUT);
-  }
+void Bounce::attach(int pin, int mode){
+  pinMode(pin, mode);
   
   this->attach(pin);
 }

--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -33,6 +33,17 @@ void Bounce::attach(int pin) {
 #endif
 }
 
+void Bounce::attach(int pin, byte mode){
+  if(mode == INPUT_PULLUP){
+    pinMode(pin, INPUT_PULLUP);
+  }
+  else{
+    pinMode(pin, INPUT);
+  }
+  
+  this->attach(pin);
+}
+
 void Bounce::interval(uint16_t interval_millis)
 {
     this->interval_millis = interval_millis;

--- a/Bounce2.h
+++ b/Bounce2.h
@@ -47,6 +47,9 @@ class Bounce
 
     // Attach to a pin (and also sets initial state)
     void attach(int pin);
+    
+    // Attach to a pin (and also sets initial state) and sets pin to mode (INPUT/INPUT_PULLUP/OUTPUT)
+    void attach(int pin, int mode);
 
     // Sets the debounce interval
     void interval(uint16_t interval_millis);


### PR DESCRIPTION
This way you only need to call attach(pin, mode) and it will also set the pinMode. Reduces the setup of a input to one line. To maintain backwards compatibility attach(pin) is still there, it's just an extension.