### PR TITLE
Partial compatibility with programs written using Bounce 1

### DIFF
--- a/Bounce2.h
+++ b/Bounce2.h
@@ -68,6 +68,14 @@ class Bounce
     // Returns the rising pin state
     bool rose();
 
+    // Partial compatibility for programs written with Bounce version 1
+    bool risingEdge() { return rose(); }
+    bool fallingEdge() { return fell(); }
+    Bounce(uint8_t pin, unsigned long interval_millis ) : Bounce() {
+        attach(pin);
+        interval(interval_millis);
+    }
+
  protected:
     unsigned long previous_millis;
     uint16_t interval_millis;


### PR DESCRIPTION
These inline functions allow backwards compatibility with many programs written for Bounce version 1.