### PR TITLE
Support Adafruit Feather M0

### DIFF
--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -11,6 +11,9 @@
 #define UNSTABLE_STATE  1
 #define STATE_CHANGED   3
 
+#ifndef _BV
+#define _BV(i) (1<<i)
+#endif
 
 Bounce::Bounce()
     : previous_millis(0)


### PR DESCRIPTION
Support SAMD processor cores, specifically the Adafruit Feather M0.

It just lacks `_BV`, which is simple to polyfill.