### PR TITLE
Analog pins and modern C++

### DIFF
--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -18,13 +18,6 @@ namespace {
 }
 
 Bounce::Bounce()
-    : previous_millis(0)
-    , interval_millis(10)
-#ifdef ANALOG_PINS
-      value(0),
-#endif
-    , state(0)
-    , pin(0)
 {}
 
 void Bounce::attach(uint8_t pin) {
@@ -149,3 +142,9 @@ bool Bounce::fell() const ///return if !DEBOUNCED or !CHANGED
 {
     return !rose();
 }
+
+#ifdef ANALOG_PINS
+uint16_t Bounce::getValue() const {
+    return this->value;
+}
+#endif

--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -9,142 +9,132 @@
 
 //This is an implementation detail that doesn't need to be seen by the outside world.
 namespace {
-    constexpr uint8_t SetBouncerFlag(const uint8_t n){
-        return (1 << n);
-    }
-    constexpr uint8_t DEBOUNCED_STATE = 0b00000000;
-    constexpr uint8_t UNSTABLE_STATE  = 0b00000001;
-    constexpr uint8_t STATE_CHANGED   = 0b00000011;
+    constexpr uint8_t DEBOUNCED_STATE = 0b00000001;
+    constexpr uint8_t UNSTABLE_STATE  = 0b00000010;
+    constexpr uint8_t STATE_CHANGED   = 0b00001000;
 }
 
-Bounce::Bounce()
-{}
+Bounce::Bounce() {
+}
 
 void Bounce::attach(uint8_t pin) {
     this->pin = pin;
-    state = 0;
+    this->state = 0;
     if (digitalRead(pin)) {
-        state = SetBouncerFlag(DEBOUNCED_STATE) | SetBouncerFlag(UNSTABLE_STATE);
+        this->state = DEBOUNCED_STATE | UNSTABLE_STATE;
     }
-#ifdef BOUNCE_LOCK_OUT
-    previous_millis = 0;
-#else
-    previous_millis = millis();
-#endif
+    #ifdef BOUNCE_LOCK_OUT
+        this->previous_millis = 0;
+    #else
+        this->previous_millis = millis();
+    #endif
 }
 
 void Bounce::attach(uint8_t pin, uint8_t mode) {
-#if defined(ARDUINO_STM_NUCLEO_F103RB) || defined(ARDUINO_GENERIC_STM32F103C)
-    pinMode(pin, (WiringPinMode)mode);
-#else
-    pinMode(pin, mode);
-#endif
+    #if defined(ARDUINO_STM_NUCLEO_F103RB) || defined(ARDUINO_GENERIC_STM32F103C)
+        pinMode(pin, (WiringPinMode)mode);
+    #else
+        pinMode(pin, mode);
+    #endif
     this->attach(pin);
 }
 
-void Bounce::interval(uint16_t interval_millis)
-{
+void Bounce::interval(uint16_t interval_millis) {
     this->interval_millis = interval_millis;
 }
 
-bool Bounce::update()
-{
+bool Bounce::update() {
 #ifdef BOUNCE_LOCK_OUT
-    state &= ~SetBouncerFlag(STATE_CHANGED);
+    this->state &= ~STATE_CHANGED;
     // Ignore everything if we are locked out
-    if (millis() - previous_millis >= interval_millis) {
-        #ifdef ANALOG_PINS
-            this->value = analogRead(this->pin);
-            bool currentState = (this->value > 50);
-        #else
-            bool currentState = digitalRead(this->pin);
-        #endif
-        if ((bool)(state & SetBouncerFlag(DEBOUNCED_STATE)) != currentState) {
-            previous_millis = millis();
-            state ^= SetBouncerFlag(DEBOUNCED_STATE);
-            state |= SetBouncerFlag(STATE_CHANGED);
+    if (millis() - this->previous_millis >= this->interval_millis) {
+    #ifdef ANALOG_PINS
+        this->value = analogRead(this->pin);
+        bool currentState = (this->value > BouncerConstants::NOISE_TOLERANCE);
+    #else
+        bool currentState = digitalRead(this->pin);
+    #endif
+        if (currentState != (bool)(this->state & DEBOUNCED_STATE)) {
+            this->previous_millis = millis();
+            this->state ^= DEBOUNCED_STATE;
+            this->state |= STATE_CHANGED;
         }
     }
-    return state & SetBouncerFlag(STATE_CHANGED);
+    return this->state & STATE_CHANGED;
 
 #elif defined BOUNCE_WITH_PROMPT_DETECTION
     // Read the state of the switch port into a temporary variable.
     #ifdef ANALOG_PINS
         this->value = analogRead(this->pin);
-        bool readState = (this->value > 50);
+        bool currentState = (this->value > BouncerConstants::NOISE_TOLERANCE);
     #else
-        bool readState = digitalRead(this->pin);
+        bool currentState = digitalRead(this->pin);
     #endif
     // Clear Changed State Flag - will be reset if we confirm a button state change.
-    state &= ~SetBouncerFlag(STATE_CHANGED);
+        this->state &= ~STATE_CHANGED;
 
-    if ( readState != (bool)(state & SetBouncerFlag(DEBOUNCED_STATE))) {
-      // We have seen a change from the current button state.
-
-      if ( millis() - previous_millis >= interval_millis ) {
-	// We have passed the time threshold, so a new change of state is allowed.
-	// set the STATE_CHANGED flag and the new DEBOUNCED_STATE.
-	// This will be prompt as long as there has been greater than interval_misllis ms since last change of input.
-	// Otherwise debounced state will not change again until bouncing is stable for the timeout period.
-	state ^= SetBouncerFlag(DEBOUNCED_STATE);
-	state |= SetBouncerFlag(STATE_CHANGED);
-      }
+    if (currentState != (bool)(state & DEBOUNCED_STATE)) {
+        // We have seen a change from the current button state.
+        if (millis() - this->previous_millis >= this->interval_millis) {
+            // We have passed the time threshold, so a new change of state is allowed.
+            // set the STATE_CHANGED flag and the new DEBOUNCED_STATE.
+            // This will be prompt as long as there has been greater than interval_misllis ms since last change of input.
+            // Otherwise debounced state will not change again until bouncing is stable for the timeout period.
+            this->state ^= DEBOUNCED_STATE;
+            this->state |= STATE_CHANGED;
+        }
     }
-
-    // If the readState is different from previous readState, reset the debounce timer - as input is still unstable
+    // If the currentState is different from previous currentState, reset the debounce timer - as input is still unstable
     // and we want to prevent new button state changes until the previous one has remained stable for the timeout.
-    if ( readState != (bool)(state & SetBouncerFlag(UNSTABLE_STATE)) ) {
-	// Update Unstable Bit to macth readState
-        state ^= SetBouncerFlag(UNSTABLE_STATE);
-        previous_millis = millis();
+    if (currentState != (bool)(this->state & UNSTABLE_STATE)) {
+        // Update Unstable Bit to macth currentState
+        this->state ^= UNSTABLE_STATE;
+        this->previous_millis = millis();
     }
     // return just the sate changed bit
-    return state & SetBouncerFlag(STATE_CHANGED);
+    return this->state & STATE_CHANGED;
 #else
     // Read the state of the switch in a temporary variable.
     #ifdef ANALOG_PINS
         this->value = analogRead(this->pin);
-        bool currentState = (this->value > 50);
+        bool currentState = (this->value > BouncerConstants::NOISE_TOLERANCE);
     #else
         bool currentState = digitalRead(this->pin);
     #endif
-    state &= ~SetBouncerFlag(STATE_CHANGED); ///reset STATE_CHANGED flag
+    this->state &= ~STATE_CHANGED; ///reset STATE_CHANGED flag
 
     // If the reading is different from last reading, reset the debounce counter
-    if (currentState != (bool)(state & SetBouncerFlag(UNSTABLE_STATE))) { /// PRESSED_STATE != UNSTABLE_STATE
-        previous_millis = millis();
-        state ^= SetBouncerFlag(UNSTABLE_STATE); ///XOR-on the UNSTABLE_STATE, reset all other flags
+    if (currentState != (bool)(this->state & UNSTABLE_STATE)) { /// PRESSED_STATE != UNSTABLE_STATE
+        this->previous_millis = millis();
+        this->state ^= UNSTABLE_STATE; ///XOR-on the UNSTABLE_STATE, reset all other flags
     }
-    if ( millis() - previous_millis >= interval_millis) { ///if enought time has passed
+    if (millis() - this->previous_millis >= this->interval_millis) { ///if enough time has passed
         // We have passed the threshold time, so the input is now stable
         // If it is different from last state, set the STATE_CHANGED flag
-        if (currentState != (bool)(state & SetBouncerFlag(DEBOUNCED_STATE))) {///PRESSED_STATE != DEBOUNCED_STATE
-            previous_millis = millis();
-            state ^= SetBouncerFlag(DEBOUNCED_STATE); /// XOR 0001 =>
-            state |= SetBouncerFlag(STATE_CHANGED);   /// iOR 1000 => turn on the STATE_CHANGED flag
+        if (currentState != (bool)(this->state & DEBOUNCED_STATE)) { ///PRESSED_STATE != DEBOUNCED_STATE
+            this->previous_millis = millis();
+            this->state ^= DEBOUNCED_STATE; /// XOR 0001 =>
+            this->state |= STATE_CHANGED;   /// iOR 1000 => turn on the STATE_CHANGED flag
         }
     }
-    return state & SetBouncerFlag(STATE_CHANGED); // return STATE_CHANGED flag
+    return this->state & STATE_CHANGED; // return STATE_CHANGED flag
 #endif
 }
 
-bool Bounce::read() const ///return if DEBOUNCED
-{
-    return state & SetBouncerFlag(DEBOUNCED_STATE);
+bool Bouncer::read() const { ///return if DEBOUNCED
+    return (this->state & DEBOUNCED_STATE);
 }
 
-bool Bounce::rose() const ///return if DEBOUNCED and CHANGED
-{
-    return (state & SetBouncerFlag(DEBOUNCED_STATE) ) && ( state & SetBouncerFlag(STATE_CHANGED));
+bool Bouncer::rose() const { ///return if DEBOUNCED and CHANGED
+    return (this->state & DEBOUNCED_STATE) && (this->state & STATE_CHANGED);
 }
 
-bool Bounce::fell() const ///return if !DEBOUNCED or !CHANGED
-{
-    return !rose();
+bool Bouncer::fell() const { ///return if !DEBOUNCED or !CHANGED
+    return !this->rose();
 }
 
 #ifdef ANALOG_PINS
-uint16_t Bounce::getValue() const {
+uint16_t Bouncer::getValue() const {
     return this->value;
 }
 #endif

--- a/Bounce2.cpp
+++ b/Bounce2.cpp
@@ -7,23 +7,31 @@
 #endif
 #include "Bounce2.h"
 
-#define DEBOUNCED_STATE 0
-#define UNSTABLE_STATE  1
-#define STATE_CHANGED   3
-
+//This is an implementation detail that doesn't need to be seen by the outside world.
+namespace {
+    constexpr uint8_t SetBouncerFlag(const uint8_t n){
+        return (1 << n);
+    }
+    constexpr uint8_t DEBOUNCED_STATE = 0b00000000;
+    constexpr uint8_t UNSTABLE_STATE  = 0b00000001;
+    constexpr uint8_t STATE_CHANGED   = 0b00000011;
+}
 
 Bounce::Bounce()
     : previous_millis(0)
     , interval_millis(10)
+#ifdef ANALOG_PINS
+      value(0),
+#endif
     , state(0)
     , pin(0)
 {}
 
-void Bounce::attach(int pin) {
+void Bounce::attach(uint8_t pin) {
     this->pin = pin;
     state = 0;
     if (digitalRead(pin)) {
-        state = _BV(DEBOUNCED_STATE) | _BV(UNSTABLE_STATE);
+        state = SetBouncerFlag(DEBOUNCED_STATE) | SetBouncerFlag(UNSTABLE_STATE);
     }
 #ifdef BOUNCE_LOCK_OUT
     previous_millis = 0;
@@ -32,13 +40,13 @@ void Bounce::attach(int pin) {
 #endif
 }
 
-void Bounce::attach(int pin, int mode){
+void Bounce::attach(uint8_t pin, uint8_t mode) {
 #if defined(ARDUINO_STM_NUCLEO_F103RB) || defined(ARDUINO_GENERIC_STM32F103C)
     pinMode(pin, (WiringPinMode)mode);
 #else
     pinMode(pin, mode);
 #endif
-  this->attach(pin);
+    this->attach(pin);
 }
 
 void Bounce::interval(uint16_t interval_millis)
@@ -49,26 +57,35 @@ void Bounce::interval(uint16_t interval_millis)
 bool Bounce::update()
 {
 #ifdef BOUNCE_LOCK_OUT
-    state &= ~_BV(STATE_CHANGED);
+    state &= ~SetBouncerFlag(STATE_CHANGED);
     // Ignore everything if we are locked out
     if (millis() - previous_millis >= interval_millis) {
-        bool currentState = digitalRead(pin);
-        if ((bool)(state & _BV(DEBOUNCED_STATE)) != currentState) {
+        #ifdef ANALOG_PINS
+            this->value = analogRead(this->pin);
+            bool currentState = (this->value > 50);
+        #else
+            bool currentState = digitalRead(this->pin);
+        #endif
+        if ((bool)(state & SetBouncerFlag(DEBOUNCED_STATE)) != currentState) {
             previous_millis = millis();
-            state ^= _BV(DEBOUNCED_STATE);
-            state |= _BV(STATE_CHANGED);
+            state ^= SetBouncerFlag(DEBOUNCED_STATE);
+            state |= SetBouncerFlag(STATE_CHANGED);
         }
     }
-    return state & _BV(STATE_CHANGED);
+    return state & SetBouncerFlag(STATE_CHANGED);
 
 #elif defined BOUNCE_WITH_PROMPT_DETECTION
     // Read the state of the switch port into a temporary variable.
-    bool readState = digitalRead(pin);
-
+    #ifdef ANALOG_PINS
+        this->value = analogRead(this->pin);
+        bool readState = (this->value > 50);
+    #else
+        bool readState = digitalRead(this->pin);
+    #endif
     // Clear Changed State Flag - will be reset if we confirm a button state change.
-    state &= ~_BV(STATE_CHANGED);
+    state &= ~SetBouncerFlag(STATE_CHANGED);
 
-    if ( readState != (bool)(state & _BV(DEBOUNCED_STATE))) {
+    if ( readState != (bool)(state & SetBouncerFlag(DEBOUNCED_STATE))) {
       // We have seen a change from the current button state.
 
       if ( millis() - previous_millis >= interval_millis ) {
@@ -76,55 +93,59 @@ bool Bounce::update()
 	// set the STATE_CHANGED flag and the new DEBOUNCED_STATE.
 	// This will be prompt as long as there has been greater than interval_misllis ms since last change of input.
 	// Otherwise debounced state will not change again until bouncing is stable for the timeout period.
-	state ^= _BV(DEBOUNCED_STATE);
-	state |= _BV(STATE_CHANGED);
+	state ^= SetBouncerFlag(DEBOUNCED_STATE);
+	state |= SetBouncerFlag(STATE_CHANGED);
       }
     }
 
     // If the readState is different from previous readState, reset the debounce timer - as input is still unstable
     // and we want to prevent new button state changes until the previous one has remained stable for the timeout.
-    if ( readState != (bool)(state & _BV(UNSTABLE_STATE)) ) {
+    if ( readState != (bool)(state & SetBouncerFlag(UNSTABLE_STATE)) ) {
 	// Update Unstable Bit to macth readState
-        state ^= _BV(UNSTABLE_STATE);
+        state ^= SetBouncerFlag(UNSTABLE_STATE);
         previous_millis = millis();
     }
     // return just the sate changed bit
-    return state & _BV(STATE_CHANGED);
+    return state & SetBouncerFlag(STATE_CHANGED);
 #else
     // Read the state of the switch in a temporary variable.
-    bool currentState = digitalRead(pin);
-    state &= ~_BV(STATE_CHANGED);
+    #ifdef ANALOG_PINS
+        this->value = analogRead(this->pin);
+        bool currentState = (this->value > 50);
+    #else
+        bool currentState = digitalRead(this->pin);
+    #endif
+    state &= ~SetBouncerFlag(STATE_CHANGED); ///reset STATE_CHANGED flag
 
     // If the reading is different from last reading, reset the debounce counter
-    if ( currentState != (bool)(state & _BV(UNSTABLE_STATE)) ) {
+    if (currentState != (bool)(state & SetBouncerFlag(UNSTABLE_STATE))) { /// PRESSED_STATE != UNSTABLE_STATE
         previous_millis = millis();
-        state ^= _BV(UNSTABLE_STATE);
-    } else
-        if ( millis() - previous_millis >= interval_millis ) {
-            // We have passed the threshold time, so the input is now stable
-            // If it is different from last state, set the STATE_CHANGED flag
-            if ((bool)(state & _BV(DEBOUNCED_STATE)) != currentState) {
-                previous_millis = millis();
-                state ^= _BV(DEBOUNCED_STATE);
-                state |= _BV(STATE_CHANGED);
-            }
+        state ^= SetBouncerFlag(UNSTABLE_STATE); ///XOR-on the UNSTABLE_STATE, reset all other flags
+    }
+    if ( millis() - previous_millis >= interval_millis) { ///if enought time has passed
+        // We have passed the threshold time, so the input is now stable
+        // If it is different from last state, set the STATE_CHANGED flag
+        if (currentState != (bool)(state & SetBouncerFlag(DEBOUNCED_STATE))) {///PRESSED_STATE != DEBOUNCED_STATE
+            previous_millis = millis();
+            state ^= SetBouncerFlag(DEBOUNCED_STATE); /// XOR 0001 =>
+            state |= SetBouncerFlag(STATE_CHANGED);   /// iOR 1000 => turn on the STATE_CHANGED flag
         }
-
-    return state & _BV(STATE_CHANGED);
+    }
+    return state & SetBouncerFlag(STATE_CHANGED); // return STATE_CHANGED flag
 #endif
 }
 
-bool Bounce::read()
+bool Bounce::read() const ///return if DEBOUNCED
 {
-    return state & _BV(DEBOUNCED_STATE);
+    return state & SetBouncerFlag(DEBOUNCED_STATE);
 }
 
-bool Bounce::rose()
+bool Bounce::rose() const ///return if DEBOUNCED and CHANGED
 {
-    return ( state & _BV(DEBOUNCED_STATE) ) && ( state & _BV(STATE_CHANGED));
+    return (state & SetBouncerFlag(DEBOUNCED_STATE) ) && ( state & SetBouncerFlag(STATE_CHANGED));
 }
 
-bool Bounce::fell()
+bool Bounce::fell() const ///return if !DEBOUNCED or !CHANGED
 {
-    return !( state & _BV(DEBOUNCED_STATE) ) && ( state & _BV(STATE_CHANGED));
+    return !rose();
 }

--- a/Bounce2.h
+++ b/Bounce2.h
@@ -29,6 +29,9 @@
 #ifndef Bounce2_h
 #define Bounce2_h
 
+// Uncomment the following line for analog pins in use
+//#define ANALOG_PINS
+
 // Uncomment the following line for "LOCK-OUT" debounce method
 //#define BOUNCE_LOCK_OUT
 
@@ -37,38 +40,38 @@
 
 #include <inttypes.h>
 
-#ifndef _BV
-#define _BV(n) (1<<(n))
-#endif
-
 class Bounce
 {
- public:
+public:
     // Create an instance of the bounce library
     Bounce();
 
     // Attach to a pin (and also sets initial state)
-    void attach(int pin);
+    void attach(uint8_t pin);
     
     // Attach to a pin (and also sets initial state) and sets pin to mode (INPUT/INPUT_PULLUP/OUTPUT)
-    void attach(int pin, int mode);
+    void attach(uint8_t pin, uint8_t mode);
 
     // Sets the debounce interval
     void interval(uint16_t interval_millis);
 
     // Updates the pin
-    // Returns 1 if the state changed
-    // Returns 0 if the state did not change
+    // Returns whether the state changed or not
     bool update();
 
     // Returns the updated pin state
-    bool read();
+    bool read() const;
 
     // Returns the falling pin state
-    bool fell();
+    bool fell() const;
 
     // Returns the rising pin state
-    bool rose();
+    bool rose() const;
+
+#ifdef ANALOG_PINS
+    // Returns the updated pin value
+    uint16_t getValue() const;
+#endif
 
     // Partial compatibility for programs written with Bounce version 1
     bool risingEdge() { return rose(); }
@@ -78,7 +81,7 @@ class Bounce
         interval(interval_millis);
     }
 
- protected:
+protected:
     unsigned long previous_millis;
     uint16_t interval_millis;
     uint8_t state;

--- a/Bounce2.h
+++ b/Bounce2.h
@@ -82,10 +82,13 @@ public:
     }
 
 protected:
-    unsigned long previous_millis;
-    uint16_t interval_millis;
-    uint8_t state;
-    uint8_t pin;
+    unsigned long previous_millis = 0;
+    uint16_t interval_millis = 10;
+#ifdef ANALOG_PINS
+    uint16_t value;
+#endif
+    uint8_t state = 0;
+    uint8_t pin = 0;
 };
 
 #endif

--- a/Bounce2.h
+++ b/Bounce2.h
@@ -40,6 +40,10 @@
 
 #include <inttypes.h>
 
+namespace BouncerConstants {
+    constexpr uint16_t NOISE_TOLERANCE = 50;
+}
+
 class Bounce
 {
 public:
@@ -85,7 +89,7 @@ protected:
     unsigned long previous_millis = 0;
     uint16_t interval_millis = 10;
 #ifdef ANALOG_PINS
-    uint16_t value;
+    uint16_t value = 0;
 #endif
     uint8_t state = 0;
     uint8_t pin = 0;


### PR DESCRIPTION
Implemented the possibility of an analog pin receiving different input values, like for example in this case:
https://drive.google.com/drive/folders/0B4EiesZHcweBQVY2NkdmRFhBNHc, where we can connect four buttons to just one pin, but each one through a step further down the line of resistors, will send a different voltage value. This way, the bouncer can clear all four buttons and tell to the Arduino which one was pressed.

Also changed the style for a more modern C++ code, like less macros and more constexpr, and more const-correctness.