### PR TITLE
Fix compilation error

### DIFF
--- a/src/Bounce2.h
+++ b/src/Bounce2.h
@@ -206,7 +206,7 @@ class Bounce
     inline bool getStateFlag(const uint8_t flag)    {return((state & flag) != 0);}
  
   public:
-    bool Bounce::changed( ) { return getStateFlag(CHANGED_STATE); }
+    bool changed( ) { return getStateFlag(CHANGED_STATE); }
 
 };
 


### PR DESCRIPTION
libraries/Bounce2/src/Bounce2.h:209:10: error: extra qualification 'Bounce::' on member 'changed' [-fpermissive]
  209 |     bool Bounce::changed( ) { return getStateFlag(CHANGED_STATE); }
      |          ^~~~~~

Regression introduced in 01e6fc9398d3a59544c20d6d8000117d6dcd0246

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>