### PR TITLE
Generic Arduino_STM32 support

### DIFF
--- a/src/Bounce2.h
+++ b/src/Bounce2.h
@@ -191,7 +191,7 @@ class Bounce
     unsigned long durationOfPreviousState;
     virtual bool readCurrentState() { return digitalRead(pin); }
     virtual void setPinMode(int pin, int mode) {
-#if defined(ARDUINO_STM_NUCLEO_F103RB) || defined(ARDUINO_GENERIC_STM32F103C)
+#if defined(ARDUINO_ARCH_STM32F1)
         pinMode(pin, (WiringPinMode)mode);
 #else
         pinMode(pin, mode);


### PR DESCRIPTION
When BluePill support have been introduced, it was not enough generic
https://github.com/thomasfredericks/Bounce2/pull/35

Board specific definition have been used instead of the generic core one:
`ARDUINO_ARCH_STM32F1`

See https://www.stm32duino.com/viewtopic.php?f=7&p=1203#p1203

Note:
* https://github.com/rogerclarkmelbourne/Arduino_STM32 also support STM32F4, so it could  be fine to add also:
`ARDUINO_ARCH_STM32F4`
* For the [STM32 core](https://github.com/stm32duino/Arduino_Core_STM32) no customization needed as it follows Arduino API.