### PR TITLE
Methods to determine whether Button is currently pressed

### DIFF
--- a/src/Bounce2.h
+++ b/src/Bounce2.h
@@ -67,7 +67,7 @@ private:
   static const uint8_t UNSTABLE_STATE  = 0b00000010;
   static const uint8_t CHANGED_STATE   = 0b00000100;
 
-protected:
+private:
   inline void changeState();
   inline void setStateFlag(const uint8_t flag)    {state |= flag;}
   inline void unsetStateFlag(const uint8_t flag)  {state &= ~flag;}
@@ -241,9 +241,8 @@ protected:
      @brief The Debouncer:Bounce:Button class. The Button class matches an electrical state to a physical action.
      */
 class Button : public Bounce{
-  private:
-    // Note : this is private as it might change in the future
-    static const uint8_t PRESSED_STATE = 0b00001000;
+protected:
+    bool stateForPressed = 1; // 
   public:
 	/*!
     @brief  Create an instance of the Button class. By default, the pressed state is matched to a HIGH electrical level.
@@ -255,10 +254,7 @@ class Button : public Bounce{
 
     @endcode
 */
-   Button(){
-     // Default to pressed state is HIGH
-     setStateFlag(PRESSED_STATE);
-   }
+   Button(){ }
 
     /*!
     @brief Set the electrical state (HIGH/LOW) that corresponds to a physical press. By default, the pressed state is matched to a HIGH electrical level.
@@ -268,17 +264,14 @@ class Button : public Bounce{
 
 */
    void setPressedState(bool state){
-    if (state)
-      setStateFlag(PRESSED_STATE);
-    else
-      unsetStateFlag(PRESSED_STATE);
+    stateForPressed = state;
   }
 
   /*!
   @brief Get the electrical state (HIGH/LOW) that corresponds to a physical press. 
   */
   inline bool getPressedState() {
-    return getStateFlag(PRESSED_STATE);
+    return stateForPressed;
   };
 
   /*!

--- a/src/Bounce2.h
+++ b/src/Bounce2.h
@@ -67,7 +67,7 @@ private:
   static const uint8_t UNSTABLE_STATE  = 0b00000010;
   static const uint8_t CHANGED_STATE   = 0b00000100;
 
-private:
+protected:
   inline void changeState();
   inline void setStateFlag(const uint8_t flag)    {state |= flag;}
   inline void unsetStateFlag(const uint8_t flag)  {state &= ~flag;}
@@ -241,8 +241,9 @@ protected:
      @brief The Debouncer:Bounce:Button class. The Button class matches an electrical state to a physical action.
      */
 class Button : public Bounce{
-protected:
-    bool stateForPressed = 1; // 
+  private:
+    // Note : this is private as it might change in the future
+    static const uint8_t PRESSED_STATE = 0b00001000;
   public:
 	/*!
     @brief  Create an instance of the Button class. By default, the pressed state is matched to a HIGH electrical level.
@@ -254,7 +255,10 @@ protected:
 
     @endcode
 */
-   Button(){ }
+   Button(){
+     // Default to pressed state is HIGH
+     setStateFlag(PRESSED_STATE);
+   }
 
     /*!
     @brief Set the electrical state (HIGH/LOW) that corresponds to a physical press. By default, the pressed state is matched to a HIGH electrical level.
@@ -264,14 +268,17 @@ protected:
 
 */
    void setPressedState(bool state){
-    stateForPressed = state;
+    if (state)
+      setStateFlag(PRESSED_STATE);
+    else
+      unsetStateFlag(PRESSED_STATE);
   }
 
   /*!
   @brief Get the electrical state (HIGH/LOW) that corresponds to a physical press. 
   */
   inline bool getPressedState() {
-    return stateForPressed;
+    return getStateFlag(PRESSED_STATE);
   };
 
   /*!

--- a/src/Bounce2.h
+++ b/src/Bounce2.h
@@ -267,21 +267,33 @@ protected:
     stateForPressed = state;
   }
 
+  /*!
+  @brief Get the electrical state (HIGH/LOW) that corresponds to a physical press. 
+  */
+  inline bool getPressedState() {
+    return stateForPressed;
+  };
+
+  /*!
+  @brief Returns true if the button is currently physically pressed.
+  */
+  inline bool isPressed() {
+    return read() == getPressedState();
+  };
+
     /*!
     @brief Returns true if the button was physically pressed          
 */
-  bool pressed() {
-    return changed() && (read() == stateForPressed);
+  inline bool pressed() {
+    return changed() && isPressed();
   };
 
         /*!
     @brief Returns true if the button was physically released          
 */
-  bool released() {
-    return  changed() && (read() != stateForPressed);
+  inline bool released() {
+    return  changed() && !isPressed();
   };
-
-
 
 };
 


### PR DESCRIPTION
Main update is to add isPressed and getPressedState methods, otherwise there is no direct public way to determine whether the button is currently pressed.

Also updated to re-use state variable from Debouncer class. Also addresses #62 